### PR TITLE
Only replace basePath if it exists

### DIFF
--- a/Controller/StaticResourcesController.php
+++ b/Controller/StaticResourcesController.php
@@ -65,7 +65,9 @@ class StaticResourcesController extends Controller
             foreach ($files as $file) {
 
                 $data = json_decode($file->getContents(), true);
-                $data['basePath'] = $request->getBaseUrl() . $data['basePath'];
+                if (array_key_exists('basePath', $data)) {
+                    $data['basePath'] = $request->getBaseUrl() . $data['basePath'];
+                }
                 $response = new JsonResponse($data);
                 return $response;
             }


### PR DESCRIPTION
If you split swagger definition up into multiple files not all files will contain a base path
